### PR TITLE
eliminating libraries not being installed issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ https://www.python.org/ftp/python/3.11.3/python-3.11.3-amd64.exe
 
 You need to extract **ALL** files into the same folder, otherwise it will **NOT** work. (except old version folder)
 
-to make the script work open CMD in admin and type in the following command `pip install -r https://raw.githubusercontent.com/fortXIV/nouserlogon-fix/main/required.txt`
+to make the script work open CMD as admin and copy the following command: `pip install -r https://raw.githubusercontent.com/fortXIV/nouserlogon-fix/main/required.txt`
 
 Locate your `pythonw.exe` in your python installed folder, open properties and set it to always run as administrator
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ https://www.python.org/ftp/python/3.11.3/python-3.11.3-amd64.exe
 
 You need to extract **ALL** files into the same folder, otherwise it will **NOT** work. (except old version folder)
 
-execute `required.bat` to install necessary libraries.
+to make the script work open CMD in admin and type in the following command `pip install -r https://raw.githubusercontent.com/fortXIV/nouserlogon-fix/main/required.txt`
 
 Locate your `pythonw.exe` in your python installed folder, open properties and set it to always run as administrator
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ https://www.python.org/ftp/python/3.11.3/python-3.11.3-amd64.exe
 
 You need to extract **ALL** files into the same folder, otherwise it will **NOT** work. (except old version folder)
 
-to make the script work open CMD as admin and copy the following command: `pip install -r https://raw.githubusercontent.com/fortXIV/nouserlogon-fix/main/required.txt`
+To make the script work, open CMD as administrator and copy the following command: `pip install -r https://raw.githubusercontent.com/fortXIV/nouserlogon-fix/main/required.txt`
 
 Locate your `pythonw.exe` in your python installed folder, open properties and set it to always run as administrator
 

--- a/required.bat
+++ b/required.bat
@@ -1,8 +1,0 @@
-@echo off
-
-py -m pip install pywinauto
-py -m pip install pywin32
-py -m pip install keyboard
-py -m pip install pyautogui
-py -m pip install opencv-python
-py -m pip install Pillow

--- a/required.txt
+++ b/required.txt
@@ -1,0 +1,7 @@
+pywinauto
+pywin32
+pygetwindow
+keyboard
+pyautogui
+opencv-python
+Pillow


### PR DESCRIPTION
I and a lot of people in tedon discord were having issues installing libraries - I then found out that this is the proper way to make a requirements.txt/bat. This should eliminate all issues with people not having the correct libraries installed.

Remember to change `pip install -r https://raw.githubusercontent.com/fortXIV/nouserlogon-fix/main/required.txt` to `pip install -r https://raw.githubusercontent.com/Megalounge/nouserlogon-fix/main/required.tx` 